### PR TITLE
remove duplicate events route in router definitions

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -41,11 +41,6 @@ class App extends LitElement {
             .resolve="${() => import('/routes/events/events.js')}">
           </lit-route>
           <lit-route
-            path="/events"
-            component="as-route-events"
-            .resolve="${() => import('/routes/events/events.js')}"
-          ></lit-route>
-          <lit-route
             path="/"
             component="as-route-home"
             .resolve="${() => import('/routes/home/home.js')}">


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
N / A

## Summary of Changes
1. Removed an extra `events/` route definition