### PR TITLE
restoring social share

### DIFF
--- a/greenwood.config.js
+++ b/greenwood.config.js
@@ -2,6 +2,7 @@ import { greenwoodPluginFontAwesome } from '@analogstudiosri/greenwood-plugin-fo
 import { greenwoodPluginTypeScript } from '@greenwood/plugin-typescript';
 import { greenwoodPluginImportCss } from '@greenwood/plugin-import-css';
 import { greenwoodPluginPostCss } from '@greenwood/plugin-postcss';
+import path from 'path';
 import analyze from 'rollup-plugin-analyzer';
 import { visualizer } from 'rollup-plugin-visualizer';
 
@@ -39,6 +40,17 @@ export default {
             filename: 'reports/stats.html'
           })
         ];
+      }
+    }, {
+      type: 'copy',
+      name: 'plugin-web-social-share',
+      provider: (compilation) => {
+        const { outputDir, projectDirectory } = compilation.context;
+
+        return [{
+          from: path.join(projectDirectory, 'node_modules/@analogstudiosri/web-social-share/dist/websocialshare'),
+          to: outputDir
+        }];
       }
     }
   ]

--- a/greenwood.config.js
+++ b/greenwood.config.js
@@ -2,9 +2,9 @@ import { greenwoodPluginFontAwesome } from '@analogstudiosri/greenwood-plugin-fo
 import { greenwoodPluginTypeScript } from '@greenwood/plugin-typescript';
 import { greenwoodPluginImportCss } from '@greenwood/plugin-import-css';
 import { greenwoodPluginPostCss } from '@greenwood/plugin-postcss';
-import path from 'path';
 import analyze from 'rollup-plugin-analyzer';
 import { visualizer } from 'rollup-plugin-visualizer';
+import rollupPluginDynamicImportVars from '@rollup/plugin-dynamic-import-vars';
 
 export default {
   mode: 'spa',
@@ -19,6 +19,14 @@ export default {
     ...greenwoodPluginFontAwesome(),
     ...greenwoodPluginTypeScript(),
     {
+      type: 'rollup',
+      name: 'rollup-plugin-import-vars',
+      provider: () => {
+        return [
+          rollupPluginDynamicImportVars()
+        ];
+      }
+    }, {
       type: 'rollup',
       name: 'rollup-plugin-analyzer',
       provider: () => {
@@ -40,17 +48,6 @@ export default {
             filename: 'reports/stats.html'
           })
         ];
-      }
-    }, {
-      type: 'copy',
-      name: 'plugin-web-social-share',
-      provider: (compilation) => {
-        const { outputDir, projectDirectory } = compilation.context;
-
-        return [{
-          from: path.join(projectDirectory, 'node_modules/@analogstudiosri/web-social-share/dist/websocialshare'),
-          to: outputDir
-        }];
       }
     }
   ]

--- a/greenwood.config.js
+++ b/greenwood.config.js
@@ -4,7 +4,7 @@ import { greenwoodPluginImportCss } from '@greenwood/plugin-import-css';
 import { greenwoodPluginPostCss } from '@greenwood/plugin-postcss';
 import analyze from 'rollup-plugin-analyzer';
 import { visualizer } from 'rollup-plugin-visualizer';
-import rollupPluginDynamicImportVars from '@rollup/plugin-dynamic-import-vars';
+import dynamicImportVariables from '@rollup/plugin-dynamic-import-vars';
 
 export default {
   mode: 'spa',
@@ -23,7 +23,7 @@ export default {
       name: 'rollup-plugin-import-vars',
       provider: () => {
         return [
-          rollupPluginDynamicImportVars()
+          dynamicImportVariables.default()
         ];
       }
     }, {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "test:tdd": "yarn test --watch"
   },
   "dependencies": {
-    "@stencil/core": "^2.11.0",
     "bootstrap": "4.0.0-alpha.4",
     "font-awesome": "4.6.3",
     "lit": "^2.0.0-rc.2",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "lit-redux-router": "~0.19.0",
     "pwa-helpers": "^0.9.1",
     "redux": "^4.0.5",
-    "redux-thunk": "^2.3.0"
+    "redux-thunk": "^2.3.0",
+    "web-social-share": "^7.2.0"
   },
   "devDependencies": {
     "@analogstudiosri/greenwood-plugin-font-awesome": "^0.2.0",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "test:tdd": "yarn test --watch"
   },
   "dependencies": {
+    "@stencil/core": "^2.11.0",
     "bootstrap": "4.0.0-alpha.4",
     "font-awesome": "4.6.3",
     "lit": "^2.0.0-rc.2",

--- a/package.json
+++ b/package.json
@@ -33,14 +33,14 @@
     "test:tdd": "yarn test --watch"
   },
   "dependencies": {
-    "@analogstudiosri/web-social-share": "^8.0.0",
     "bootstrap": "4.0.0-alpha.4",
     "font-awesome": "4.6.3",
     "lit": "^2.0.0-rc.2",
     "lit-redux-router": "~0.19.0",
     "pwa-helpers": "^0.9.1",
     "redux": "^4.0.5",
-    "redux-thunk": "^2.3.0"
+    "redux-thunk": "^2.3.0",
+    "web-social-share": "^8.0.1"
   },
   "devDependencies": {
     "@analogstudiosri/greenwood-plugin-font-awesome": "^0.2.0",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "@greenwood/plugin-postcss": "^0.20.0",
     "@greenwood/plugin-typescript": "^0.20.0",
     "@ls-lint/ls-lint": "^1.10.0",
+    "@rollup/plugin-dynamic-import-vars": "^1.4.1",
     "@storybook/addon-actions": "^6.3.2",
     "@storybook/addon-essentials": "^6.3.2",
     "@storybook/addon-links": "^6.3.2",

--- a/package.json
+++ b/package.json
@@ -33,14 +33,14 @@
     "test:tdd": "yarn test --watch"
   },
   "dependencies": {
+    "@analogstudiosri/web-social-share": "^8.0.0",
     "bootstrap": "4.0.0-alpha.4",
     "font-awesome": "4.6.3",
     "lit": "^2.0.0-rc.2",
     "lit-redux-router": "~0.19.0",
     "pwa-helpers": "^0.9.1",
     "redux": "^4.0.5",
-    "redux-thunk": "^2.3.0",
-    "web-social-share": "^7.2.0"
+    "redux-thunk": "^2.3.0"
   },
   "devDependencies": {
     "@analogstudiosri/greenwood-plugin-font-awesome": "^0.2.0",

--- a/src/components/social-share/social-share.css
+++ b/src/components/social-share/social-share.css
@@ -1,0 +1,1 @@
+@import '../../theme.css';

--- a/src/components/social-share/social-share.css
+++ b/src/components/social-share/social-share.css
@@ -1,1 +1,15 @@
 @import '../../theme.css';
+
+button {
+  background-color: var(--color-tertiary);
+  border: 2px solid var(--black)!important;
+}
+
+svg {
+  height: 20px;
+}
+
+i.fa {
+  color: #00aced;
+  width: 1.4rem;
+}

--- a/src/components/social-share/social-share.ts
+++ b/src/components/social-share/social-share.ts
@@ -1,0 +1,51 @@
+import { css, html, LitElement, unsafeCSS, TemplateResult } from 'lit';
+import { customElement } from 'lit/decorators.js';
+// import navigationCss from './navigation.css?type=css';
+import 'web-social-share';
+
+@customElement('app-social-share')
+export class NavigationComponent extends LitElement {
+  // static styles = css`${unsafeCSS(navigationCss)}`;
+
+  protected render(): TemplateResult {
+    const share = {
+      displayNames: true,
+      config: [{
+        facebook: {
+          socialShareUrl: 'https://peterpeterparker.io'
+        }
+      }, {
+        twitter: {
+          socialShareUrl: 'https://peterpeterparker.io'
+        }
+      }]
+    };
+
+    return html`
+      <div class="container">
+        <div class="row">
+
+          <h2 class="header">Interact + Share</h2>
+          <web-social-share show="true" share=${share}></web-social-share>
+          <!--
+          <a class="btn btn-social-icon btn-facebook">
+            <button ceiboShare  [facebook]="{u: getCurrentPageUrl()}"></button>
+            <span class="fa fa-facebook"></span>
+          </a>
+      
+          <a class="btn btn-social-icon btn-twitter">
+            <button ceiboShare  [twitter]="{url: getCurrentPageUrl(), hashtags:'keepingitreel'}"></button>
+            <span class="fa fa-twitter"></span>
+          </a>
+      
+          <a class="btn btn-social-icon btn-google">
+            <button ceiboShare  [googlePlus]="{url: getCurrentPageUrl()}"></button>
+            <span class="fa fa-google"></span>
+          </a>
+          -->
+
+        </div>
+      </div>
+    `;
+  }
+}

--- a/src/components/social-share/social-share.ts
+++ b/src/components/social-share/social-share.ts
@@ -1,11 +1,11 @@
 import { css, html, LitElement, unsafeCSS, TemplateResult } from 'lit';
 import { customElement } from 'lit/decorators.js';
-// import navigationCss from './navigation.css?type=css';
-import 'web-social-share';
+import socialShareCss from './social-share.css?type=css';
+import '@analogstudiosri/web-social-share';
 
 @customElement('app-social-share')
 export class NavigationComponent extends LitElement {
-  // static styles = css`${unsafeCSS(navigationCss)}`;
+  static styles = css`${unsafeCSS(socialShareCss)}`;
 
   protected render(): TemplateResult {
     const share = {
@@ -26,7 +26,10 @@ export class NavigationComponent extends LitElement {
         <div class="row">
 
           <h2 class="header">Interact + Share</h2>
-          <web-social-share show="true" share=${share}></web-social-share>
+          <web-social-share show="true" .share=${share}>
+            <i class="fa fa-facebook" slot="facebook" style="color: #00aced; width: 1.4rem;"></i>
+            <i class="fa fa-twitter" slot="twitter" style="color: #00aced; width: 1.4rem;"></i>
+          </web-social-share>
           <!--
           <a class="btn btn-social-icon btn-facebook">
             <button ceiboShare  [facebook]="{u: getCurrentPageUrl()}"></button>

--- a/src/components/social-share/social-share.ts
+++ b/src/components/social-share/social-share.ts
@@ -1,7 +1,7 @@
 import { css, html, LitElement, unsafeCSS, TemplateResult } from 'lit';
 import { customElement } from 'lit/decorators.js';
 import socialShareCss from './social-share.css?type=css';
-import '@analogstudiosri/web-social-share';
+import 'web-social-share';
 
 @customElement('app-social-share')
 export class NavigationComponent extends LitElement {

--- a/src/components/social-share/social-share.ts
+++ b/src/components/social-share/social-share.ts
@@ -1,5 +1,5 @@
 import { css, html, LitElement, unsafeCSS, TemplateResult } from 'lit';
-import { customElement } from 'lit/decorators.js';
+import { customElement, property } from 'lit/decorators.js';
 import socialShareCss from './social-share.css?type=css';
 import 'web-social-share';
 
@@ -7,45 +7,61 @@ import 'web-social-share';
 export class NavigationComponent extends LitElement {
   static styles = css`${unsafeCSS(socialShareCss)}`;
 
-  protected render(): TemplateResult {
-    const share = {
+  @property() show = false;
+  shareConfig = {};
+
+  constructor() {
+    super();
+
+    const socialShareUrl = window.location.href;
+
+    this.shareConfig = {
       displayNames: true,
       config: [{
         facebook: {
-          socialShareUrl: 'https://peterpeterparker.io'
+          socialShareUrl
         }
       }, {
         twitter: {
-          socialShareUrl: 'https://peterpeterparker.io'
+          socialShareUrl
+        }
+      }, {
+        pinterest: {
+          socialShareUrl
         }
       }]
     };
+  }
 
+  connectedCallback() {
+    super.connectedCallback();
+
+    this.shadowRoot.addEventListener('closed', () => {
+      this.toggleShowSocialShare();
+    });
+  }
+
+  toggleShowSocialShare() {
+    this.show = !this.show;
+  }
+
+  protected render(): TemplateResult {
     return html`
       <div class="container">
         <div class="row">
 
           <h2 class="header">Interact + Share</h2>
-          <web-social-share show="true" .share=${share}>
-            <i class="fa fa-facebook" slot="facebook" style="color: #00aced; width: 1.4rem;"></i>
-            <i class="fa fa-twitter" slot="twitter" style="color: #00aced; width: 1.4rem;"></i>
+
+          <button type="button" class="btn" @click=${this.toggleShowSocialShare}>
+            <svg class="svg-inline--fa fa-share-alt fa-w-14" aria-hidden="true" data-prefix="fas" data-icon="share-alt" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512" data-fa-i2svg=""><path fill="currentColor" d="M352 320c-22.608 0-43.387 7.819-59.79 20.895l-102.486-64.054a96.551 96.551 0 0 0 0-41.683l102.486-64.054C308.613 184.181 329.392 192 352 192c53.019 0 96-42.981 96-96S405.019 0 352 0s-96 42.981-96 96c0 7.158.79 14.13 2.276 20.841L155.79 180.895C139.387 167.819 118.608 160 96 160c-53.019 0-96 42.981-96 96s42.981 96 96 96c22.608 0 43.387-7.819 59.79-20.895l102.486 64.054A96.301 96.301 0 0 0 256 416c0 53.019 42.981 96 96 96s96-42.981 96-96-42.981-96-96-96z"></path></svg>
+            SHARE THIS PAGE
+          </button>
+
+          <web-social-share class="wss" .show=${this.show} .share=${this.shareConfig}>
+            <i class="fa fa-facebook" slot="facebook"></i>
+            <i class="fa fa-twitter" slot="twitter"></i>
+            <i class="fa fa-pinterest" slot="pinterest"></i>
           </web-social-share>
-          <!--
-          <a class="btn btn-social-icon btn-facebook">
-            <button ceiboShare  [facebook]="{u: getCurrentPageUrl()}"></button>
-            <span class="fa fa-facebook"></span>
-          </a>
-      
-          <a class="btn btn-social-icon btn-twitter">
-            <button ceiboShare  [twitter]="{url: getCurrentPageUrl(), hashtags:'keepingitreel'}"></button>
-            <span class="fa fa-twitter"></span>
-          </a>
-      
-          <a class="btn btn-social-icon btn-google">
-            <button ceiboShare  [googlePlus]="{url: getCurrentPageUrl()}"></button>
-            <span class="fa fa-google"></span>
-          </a>
-          -->
 
         </div>
       </div>

--- a/src/routes/albums/album-details.ts
+++ b/src/routes/albums/album-details.ts
@@ -5,6 +5,7 @@ import { getAlbumById } from '../../services/albums/albums-service.ts';
 import { modelAlbum } from '../../components/card/card.model.ts';
 import { Album } from '../../services/albums/album.model.ts';
 import '../../components/card/card.ts';
+import '../../components/social-share/social-share.ts';
 import albumsCss from './albums.css?type=css';
 
 @customElement('as-route-album-details')
@@ -45,7 +46,7 @@ export class AlbumDetailsRouteComponent extends LitElement {
           <div class="row">
 
             <div class="col-xs-4 hidden-sm-down">
-              <as-social-share></as-social-share>
+              <app-social-share></app-social-share>
             </div>
 
             <div class="col-xs-6">

--- a/src/routes/artists/artist-details.ts
+++ b/src/routes/artists/artist-details.ts
@@ -8,6 +8,7 @@ import { modelArtist, modelAlbum } from '../../components/card/card.model.ts';
 import { Artist } from '../../services/artists/artist.model.ts';
 import { Album } from '../../services/album/album.model.ts';
 import '../../components/card/card.ts';
+import '../../components/social-share/social-share.ts';
 import artistsCss from './artists.css?type=css';
 
 @customElement('as-route-artist-details')
@@ -56,7 +57,7 @@ export class ArtistDetailsRouteComponent extends LitElement {
           <div class="row">
 
             <div class="col-xs-4 hidden-sm-down">
-              <as-social-share></as-social-share>
+              <app-social-share></app-social-share>
             </div>
 
             <div class="col-xs-6">

--- a/src/routes/events/event-details.ts
+++ b/src/routes/events/event-details.ts
@@ -3,6 +3,7 @@ import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 import { customElement, property } from 'lit/decorators.js';
 import { getEventById } from '../../services/events/events-service.ts';
 import { Event } from '../../services/events/event.model.ts';
+import '../../components/social-share/social-share.ts';
 import eventsCss from './events.css?type=css';
 
 @customElement('as-route-event-details')
@@ -60,7 +61,7 @@ export class EventDetailsRouteComponent extends LitElement {
               <p style="color: var(--color-primary)">${unsafeHTML(event.description)}</p>
             </div>
           </div>
-          <as-social-share></as-social-share>
+          <app-social-share></app-social-share>
         </div>
       `;
     }

--- a/src/routes/events/event-details.ts
+++ b/src/routes/events/event-details.ts
@@ -51,9 +51,9 @@ export class EventDetailsRouteComponent extends LitElement {
         </style>
 
         <div class="as-events-container">
-
           <div id="as-event-detail-container">
-            <i class="cal-icon fa fa-calendar-o" style="font-size: 5rem;width:20%"></i>
+            <app-social-share></app-social-share>
+            <i class="cal-icon fa fa-calendar-o" style="font-size: 5rem;width:10%"></i>
             <div id="as-event-info">
               <p>Event Title: ${event.title}</p>
               <p>Event Date: ${this.formatEventTime(event.startTime)}</p>
@@ -61,7 +61,6 @@ export class EventDetailsRouteComponent extends LitElement {
               <p style="color: var(--color-primary)">${unsafeHTML(event.description)}</p>
             </div>
           </div>
-          <app-social-share></app-social-share>
         </div>
       `;
     }

--- a/src/routes/events/events.css
+++ b/src/routes/events/events.css
@@ -34,7 +34,7 @@
 #as-event-detail-container {
   display: flex;
   font-size: 1.2rem;
-  padding: 3rem;
+  padding: 2rem;
 
   @media(max-width: 768px) {
     flex-direction: column;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1480,11 +1480,6 @@
     estree-walker "^1.0.1"
     picomatch "^2.2.2"
 
-"@stencil/core@^2.11.0":
-  version "2.11.0"
-  resolved "https://registry.yarnpkg.com/@stencil/core/-/core-2.11.0.tgz#8accc2791e2c34cce2d2aa8b40864dd40be4e10c"
-  integrity sha512-/IubCWhVXCguyMUp/3zGrg3c882+RJNg/zpiKfyfJL3kRCOwe+/MD8OoAXVGdd+xAohZKIi1Ik+EHFlsptsjLg==
-
 "@storybook/addon-actions@6.3.6", "@storybook/addon-actions@^6.3.2":
   version "6.3.6"
   resolved "https://registry.yarnpkg.com/@storybook/addon-actions/-/addon-actions-6.3.6.tgz#691d61d6aca9c4b3edba50c531cbe4d4139ed451"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7,13 +7,6 @@
   resolved "https://registry.yarnpkg.com/@analogstudiosri/greenwood-plugin-font-awesome/-/greenwood-plugin-font-awesome-0.2.1.tgz#fb7774846278a2005370088b3b718a1c50ee7d41"
   integrity sha512-4GYUUYNcn60yQNHyB4p7GQKEaxdhaNkSPWCpw+hhjTEgudQ1Ij4sAAeDn453iL+bpiadw2MFyCMUu/Zmdyd8og==
 
-"@analogstudiosri/web-social-share@^8.0.0":
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/@analogstudiosri/web-social-share/-/web-social-share-8.0.0.tgz#5e7040ac84113fdfd7c37859ffe3376b5a8d6fec"
-  integrity sha512-AJeN6TXNzHjpecwsCm3zQY8VbrpDw51ms4qXXtw/j3Y1W80GeBfWnG2UBeYTqpWO4K6nfYai5gDcL0RU2waCIA==
-  dependencies:
-    "@stencil/core" "^2.11.0"
-
 "@babel/code-frame@7.10.4":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.10.4.tgz#168da1a36e90da68ae8d49c0f1b48c7c6249213a"
@@ -1496,11 +1489,6 @@
     "@types/estree" "0.0.39"
     estree-walker "^1.0.1"
     picomatch "^2.2.2"
-
-"@stencil/core@^2.11.0":
-  version "2.11.0"
-  resolved "https://registry.yarnpkg.com/@stencil/core/-/core-2.11.0.tgz#8accc2791e2c34cce2d2aa8b40864dd40be4e10c"
-  integrity sha512-/IubCWhVXCguyMUp/3zGrg3c882+RJNg/zpiKfyfJL3kRCOwe+/MD8OoAXVGdd+xAohZKIi1Ik+EHFlsptsjLg==
 
 "@storybook/addon-actions@6.3.6", "@storybook/addon-actions@^6.3.2":
   version "6.3.6"
@@ -12698,6 +12686,11 @@ web-namespaces@^1.0.0:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/web-namespaces/-/web-namespaces-1.1.4.tgz#bc98a3de60dadd7faefc403d1076d529f5e030ec"
   integrity sha512-wYxSGajtmoP4WxfejAPIr4l0fVh+jeMXZb08wNc0tMg6xsfZXj3cECqIK0G7ZAqUq0PP8WlMDtaOGVBTAWztNw==
+
+web-social-share@^8.0.1:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/web-social-share/-/web-social-share-8.0.1.tgz#460fc6120f97371a840bec2b87e2a7a5bed26360"
+  integrity sha512-SdYm76yaFDRbAm+2n+mVi7q/tgg+UqX8BDKwvIWTymssfB9CfyH9uyXPzh2o3Kfa1SIeIGY0lmExxVLdYdGueA==
 
 webidl-conversions@^6.1.0:
   version "6.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7,6 +7,13 @@
   resolved "https://registry.yarnpkg.com/@analogstudiosri/greenwood-plugin-font-awesome/-/greenwood-plugin-font-awesome-0.2.1.tgz#fb7774846278a2005370088b3b718a1c50ee7d41"
   integrity sha512-4GYUUYNcn60yQNHyB4p7GQKEaxdhaNkSPWCpw+hhjTEgudQ1Ij4sAAeDn453iL+bpiadw2MFyCMUu/Zmdyd8og==
 
+"@analogstudiosri/web-social-share@^8.0.0":
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/@analogstudiosri/web-social-share/-/web-social-share-8.0.0.tgz#5e7040ac84113fdfd7c37859ffe3376b5a8d6fec"
+  integrity sha512-AJeN6TXNzHjpecwsCm3zQY8VbrpDw51ms4qXXtw/j3Y1W80GeBfWnG2UBeYTqpWO4K6nfYai5gDcL0RU2waCIA==
+  dependencies:
+    "@stencil/core" "^2.11.0"
+
 "@babel/code-frame@7.10.4":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.10.4.tgz#168da1a36e90da68ae8d49c0f1b48c7c6249213a"
@@ -1479,6 +1486,11 @@
     "@types/estree" "0.0.39"
     estree-walker "^1.0.1"
     picomatch "^2.2.2"
+
+"@stencil/core@^2.11.0":
+  version "2.11.0"
+  resolved "https://registry.yarnpkg.com/@stencil/core/-/core-2.11.0.tgz#8accc2791e2c34cce2d2aa8b40864dd40be4e10c"
+  integrity sha512-/IubCWhVXCguyMUp/3zGrg3c882+RJNg/zpiKfyfJL3kRCOwe+/MD8OoAXVGdd+xAohZKIi1Ik+EHFlsptsjLg==
 
 "@storybook/addon-actions@6.3.6", "@storybook/addon-actions@^6.3.2":
   version "6.3.6"
@@ -12671,11 +12683,6 @@ web-namespaces@^1.0.0:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/web-namespaces/-/web-namespaces-1.1.4.tgz#bc98a3de60dadd7faefc403d1076d529f5e030ec"
   integrity sha512-wYxSGajtmoP4WxfejAPIr4l0fVh+jeMXZb08wNc0tMg6xsfZXj3cECqIK0G7ZAqUq0PP8WlMDtaOGVBTAWztNw==
-
-web-social-share@^7.2.0:
-  version "7.3.0"
-  resolved "https://registry.yarnpkg.com/web-social-share/-/web-social-share-7.3.0.tgz#cc1248831846caf32208b4f0dca7316c23e606ba"
-  integrity sha512-bDuNy7NX3MiuGj6qBAJTM2K1rHgKuqfb7BmbhL37dZTB4MQFyvzhuJU8d4CyfDoudllHa6JfcGXURQWvlA05dQ==
 
 webidl-conversions@^6.1.0:
   version "6.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -12672,6 +12672,11 @@ web-namespaces@^1.0.0:
   resolved "https://registry.yarnpkg.com/web-namespaces/-/web-namespaces-1.1.4.tgz#bc98a3de60dadd7faefc403d1076d529f5e030ec"
   integrity sha512-wYxSGajtmoP4WxfejAPIr4l0fVh+jeMXZb08wNc0tMg6xsfZXj3cECqIK0G7ZAqUq0PP8WlMDtaOGVBTAWztNw==
 
+web-social-share@^7.2.0:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/web-social-share/-/web-social-share-7.2.0.tgz#0490a315b5532d4033528be5fcda0f76efe82948"
+  integrity sha512-PZ737Bgla7maguIe8g8C2N2odq+JALbaG0pMmhDYmjqDwvXY7IRg1XIJmqEMKthN5j11O/MmmV2nQkKnP0crxw==
+
 webidl-conversions@^6.1.0:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-6.1.0.tgz#9111b4d7ea80acd40f5270d666621afa78b69514"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1480,6 +1480,11 @@
     estree-walker "^1.0.1"
     picomatch "^2.2.2"
 
+"@stencil/core@^2.11.0":
+  version "2.11.0"
+  resolved "https://registry.yarnpkg.com/@stencil/core/-/core-2.11.0.tgz#8accc2791e2c34cce2d2aa8b40864dd40be4e10c"
+  integrity sha512-/IubCWhVXCguyMUp/3zGrg3c882+RJNg/zpiKfyfJL3kRCOwe+/MD8OoAXVGdd+xAohZKIi1Ik+EHFlsptsjLg==
+
 "@storybook/addon-actions@6.3.6", "@storybook/addon-actions@^6.3.2":
   version "6.3.6"
   resolved "https://registry.yarnpkg.com/@storybook/addon-actions/-/addon-actions-6.3.6.tgz#691d61d6aca9c4b3edba50c531cbe4d4139ed451"
@@ -12673,9 +12678,9 @@ web-namespaces@^1.0.0:
   integrity sha512-wYxSGajtmoP4WxfejAPIr4l0fVh+jeMXZb08wNc0tMg6xsfZXj3cECqIK0G7ZAqUq0PP8WlMDtaOGVBTAWztNw==
 
 web-social-share@^7.2.0:
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/web-social-share/-/web-social-share-7.2.0.tgz#0490a315b5532d4033528be5fcda0f76efe82948"
-  integrity sha512-PZ737Bgla7maguIe8g8C2N2odq+JALbaG0pMmhDYmjqDwvXY7IRg1XIJmqEMKthN5j11O/MmmV2nQkKnP0crxw==
+  version "7.3.0"
+  resolved "https://registry.yarnpkg.com/web-social-share/-/web-social-share-7.3.0.tgz#cc1248831846caf32208b4f0dca7316c23e606ba"
+  integrity sha512-bDuNy7NX3MiuGj6qBAJTM2K1rHgKuqfb7BmbhL37dZTB4MQFyvzhuJU8d4CyfDoudllHa6JfcGXURQWvlA05dQ==
 
 webidl-conversions@^6.1.0:
   version "6.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1438,6 +1438,16 @@
     prop-types "^15.6.1"
     react-lifecycles-compat "^3.0.4"
 
+"@rollup/plugin-dynamic-import-vars@^1.4.1":
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/@rollup/plugin-dynamic-import-vars/-/plugin-dynamic-import-vars-1.4.1.tgz#ef6d042cd826ba05df6975c8a2612700cf0820ce"
+  integrity sha512-izHpMs9w8U8CLwyHTXE55H4ytGVaf2ZtlKIWxKigghw6ZC6Mx6AXCsixSY6JOchuX9BN4ZkeN8egLRTS+BxO+w==
+  dependencies:
+    "@rollup/pluginutils" "^3.1.0"
+    estree-walker "^2.0.1"
+    globby "^11.0.1"
+    magic-string "^0.25.7"
+
 "@rollup/plugin-node-resolve@^11.0.1":
   version "11.2.1"
   resolved "https://registry.yarnpkg.com/@rollup/plugin-node-resolve/-/plugin-node-resolve-11.2.1.tgz#82aa59397a29cd4e13248b106e6a4a1880362a60"
@@ -5733,6 +5743,11 @@ estree-walker@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-1.0.1.tgz#31bc5d612c96b704106b477e6dd5d8aa138cb700"
   integrity sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==
+
+estree-walker@^2.0.1:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-2.0.2.tgz#52f010178c2a4c117a7757cfe942adb7d2da4cac"
+  integrity sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==
 
 esutils@^2.0.2:
   version "2.0.3"


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
resolves #39 

## Summary of Changes
1. Restored social sharing using [**web-social-share**](https://www.npmjs.com/package/web-social-share)
1. Swapped Google with Pinterest (since Google+ is no more)

![Screen Shot 2021-12-23 at 6 40 17 PM](https://user-images.githubusercontent.com/895923/147299770-20aa463f-1c01-4088-8b71-52ef34408c8c.png)
![Screen Shot 2021-12-10 at 7 43 44 PM](https://user-images.githubusercontent.com/895923/145657510-3b24cf31-82d5-4109-9dd6-f83f099bcd4a.png)

So there seem to be some issues([1](https://github.com/ionic-team/stencil/issues/2826), [2](https://github.com/ionic-team/stencil/issues/2512) with Stencil that made progress on this a bit challenging, but with a little tweaking to [a fork](https://github.com/AnalogStudiosRI/web-social-share/pull/1), I got things working by:
1. pointing the `module` field to [_dist/websocialshare/websocialshare.esm.js_](https://unpkg.com/browse/web-social-share@7.3.1/dist/websocialshare/websocialshare.esm.js) instead of [_dist/esm/index.js_](https://unpkg.com/browse/web-social-share@7.3.1/dist/esm/index.js), which was just resolving to to an empty file
1. Unfortunately things break down a bit more when building for production, and it looks like some of the other [_dist/ files](https://unpkg.com/browse/web-social-share@8.0.0/dist/websocialshare/) need to be there?  My guess is Rollup doesn't know how to [bundle variables in a dynamic import](https://unpkg.com/browse/web-social-share@8.0.0/dist/websocialshare/p-12f96bea.js)?
    ```js
    import(`./${n}.entry.js`).then((e=>(D.set(n,e),e[t])),B)
    ```
     This was solved by adding a Rollup plugin specifically for handling [variables in dynamic imports](https://github.com/rollup/plugins/tree/master/packages/dynamic-import-vars).

<details>
Tried manually copying those files and now getting this?  So... progress?
![Screen Shot 2021-12-10 at 8 10 27 PM](https://user-images.githubusercontent.com/895923/145658475-d845a65c-a6c3-4ef1-bdde-a110ab613882.png)

  <img src="https://user-images.githubusercontent.com/895923/145657629-caf0f913-5ce1-42c0-87b0-985e57d9fa0d.png">
  <img src="https://user-images.githubusercontent.com/895923/145657628-6bf9e33c-ba06-48ef-9807-5a1597f8ca0f.png">
</details>

## TODOs
1. [x] Fix for production `build` command
1. [x] Get the share into its place on the left top of the page
1. [ ] Get upstream fix from Greenwood - https://github.com/ProjectEvergreen/greenwood/issues/820