### PR TITLE
deduped CSS and refactored some WCs to emit light DOM and not use Sha…

### DIFF
--- a/src/components/card/card.css
+++ b/src/components/card/card.css
@@ -1,5 +1,3 @@
-@import "../../theme.css";
-
 .as-card {
 
   & a {

--- a/src/components/card/card.ts
+++ b/src/components/card/card.ts
@@ -1,4 +1,4 @@
-import { css, html, LitElement, unsafeCSS, TemplateResult } from 'lit';
+import { html, LitElement, TemplateResult } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 import { Details } from './card.model.ts';
@@ -8,12 +8,18 @@ import cardCss from './card.css?type=css';
 export class CardComponent extends LitElement {
   @property() details: Details;
 
-  static styles = css`${unsafeCSS(cardCss)}`;
-
+  createRenderRoot(): Element | ShadowRoot {
+    return this;
+  }
+  
   protected render():TemplateResult {
     const { details } = this;
 
     return html`
+      <style>
+        ${cardCss}
+      </style>
+
       <div class="container as-card">
         <div class="row">
           <!-- why doesn't col-xs-12 work here -->

--- a/src/components/events-calendar/events-calendar.css
+++ b/src/components/events-calendar/events-calendar.css
@@ -1,6 +1,4 @@
-@import '../../theme.css';
-
-:host {
+.host {
   
   & .as-events-calendar__header {
     display: flex;

--- a/src/components/events-calendar/events-calendar.ts
+++ b/src/components/events-calendar/events-calendar.ts
@@ -7,7 +7,6 @@ import eventsCalendarCss from './events-calendar.css?type=css';
 
 @customElement('app-events-calendar')
 export class EventsCalendarComponent extends LitElement {
-
   private DAYS_IN_WEEK = 7;
   private MAX_CALENDAR_SPACES = 35;
   private CALENDAR = [
@@ -126,75 +125,81 @@ export class EventsCalendarComponent extends LitElement {
     }
   }
 
+  createRenderRoot(): Element | ShadowRoot {
+    return this;
+  }
+  
   protected render(): TemplateResult {
     return html`
       <style>
         ${eventsCalendarCss}
       </style>
+      
+      <div class="host">
+        <div class="as-events-calendar">
+          <div class="as-events-calendar__header">
+            <button type="button" class="btn btn-default btn-sm as-events-calendar__btn" @click="${this.shiftToPreviousMonth}" tabindex="-1">
+              <i class="fa fa-arrow-left"></i>
+            </button>
 
-      <div class="as-events-calendar">
-        <div class="as-events-calendar__header">
-          <button type="button" class="btn btn-default btn-sm as-events-calendar__btn" @click="${this.shiftToPreviousMonth}" tabindex="-1">
-            <i class="fa fa-arrow-left"></i>
-          </button>
+            <h3 class="as-events-calendar__header-text">Event Calendar<br><span class="as-events-calendar__month">${this.getHeaderText()}</span></h3>
 
-          <h3 class="as-events-calendar__header-text">Event Calendar<br><span class="as-events-calendar__month">${this.getHeaderText()}</span></h3>
+            <button type="button" class="btn btn-default btn-sm as-events-calendar__btn" @click="${this.shiftToNextMonth}" tabindex="-1">
+              <i class="fa fa-arrow-right"></i>
+            </button>
+          </div>
 
-          <button type="button" class="btn btn-default btn-sm as-events-calendar__btn" @click="${this.shiftToNextMonth}" tabindex="-1">
-            <i class="fa fa-arrow-right"></i>
-          </button>
-        </div>
+          <div class="as-events-calendar__days">
+            <div class="as-events-calendar__day-name">Sun</div>
+            <div class="as-events-calendar__day-name">Mon</div>
+            <div class="as-events-calendar__day-name">Tue</div>
+            <div class="as-events-calendar__day-name">Wed</div>
+            <div class="as-events-calendar__day-name">Thu</div>
+            <div class="as-events-calendar__day-name">Fri</div>
+            <div class="as-events-calendar__day-name">Sat</div>
+          </div>
 
-        <div class="as-events-calendar__days">
-          <div class="as-events-calendar__day-name">Sun</div>
-          <div class="as-events-calendar__day-name">Mon</div>
-          <div class="as-events-calendar__day-name">Tue</div>
-          <div class="as-events-calendar__day-name">Wed</div>
-          <div class="as-events-calendar__day-name">Thu</div>
-          <div class="as-events-calendar__day-name">Fri</div>
-          <div class="as-events-calendar__day-name">Sat</div>
-        </div>
+          ${
+            this.currentMonthData.map((week) => {
+              return html`
+                <div class="as-events-calendar__week">
+                  ${
+                    week.map((day) => {
+                      const dayNotInMonthContent = !day.date ? unsafeHTML('<div></div>') : '';
+                      const dayInMonthContent = day.date && !day.hasEvents
+                        ? day.date
+                        : '';
+                      const eventsInDayContent = day.hasEvents
+                        ? day.events.map((event) => {
+                          return html`
+                            <span class="as-events-calendar__day-event">
+                              <a class="as-events-calendar__day-event" href="/events/${event.id}" title="${event.title}">
+                                <i class="fa fa-calendar-check-o"></i>
+                              </a>
+                            </span>
+                          `;
+                        })
+                        : '';
 
-        ${
-          this.currentMonthData.map((week) => {
-            return html`
-              <div class="as-events-calendar__week">
-                ${
-                  week.map((day) => {
-                    const dayNotInMonthContent = !day.date ? unsafeHTML('<div></div>') : '';
-                    const dayInMonthContent = day.date && !day.hasEvents
-                      ? day.date
-                      : '';
-                    const eventsInDayContent = day.hasEvents
-                      ? day.events.map((event) => {
-                        return html`
-                          <span class="as-events-calendar__day-event">
-                            <a class="as-events-calendar__day-event" href="/events/${event.id}" title="${event.title}">
-                              <i class="fa fa-calendar-check-o"></i>
-                            </a>
-                          </span>
-                        `;
-                      })
-                      : '';
+                      return html`
+                        <div class="as-events-calendar__day">
+                          <!--day not in month-->
+                          ${dayNotInMonthContent}
 
-                    return html`
-                      <div class="as-events-calendar__day">
-                        <!--day not in month-->
-                        ${dayNotInMonthContent}
+                          <!--day in month without event-->
+                          ${dayInMonthContent}
 
-                        <!--day in month without event-->
-                        ${dayInMonthContent}
-
-                        <!--day with event if there's an event-->
-                        ${eventsInDayContent}
-                      </div>
-                    `;
-                  })
-                }
-              </div>
-            `;
-          })
-        }
+                          <!--day with event if there's an event-->
+                          ${eventsInDayContent}
+                        </div>
+                      `;
+                    })
+                  }
+                </div>
+              `;
+            })
+          }
+          </div>
         </div>
       </div>
     `;

--- a/src/components/footer/footer.css
+++ b/src/components/footer/footer.css
@@ -1,6 +1,4 @@
-@import '../../theme.css';
-
-:host {
+footer {
   .copyright-text {
     margin: 10px auto;
     text-align: center;

--- a/src/components/footer/footer.ts
+++ b/src/components/footer/footer.ts
@@ -1,10 +1,9 @@
-import { css, html, LitElement, unsafeCSS, TemplateResult } from 'lit';
+import { html, LitElement, TemplateResult } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import footerCss from './footer.css?type=css';
 
 @customElement('app-footer')
 export class FooterComponent extends LitElement {
-  static styles = css`${unsafeCSS(footerCss)}`;
 
   @property() private STARTING_YEAR = 2007;
   @property() private currentYear = new Date().getFullYear();
@@ -13,6 +12,10 @@ export class FooterComponent extends LitElement {
     const { currentYear, STARTING_YEAR } = this;
 
     return html`
+      <style>
+        ${footerCss}
+      </style>
+
       <footer class="container as-footer">
         <div class="row">
 

--- a/src/components/header/header.css
+++ b/src/components/header/header.css
@@ -1,5 +1,3 @@
-@import "../../theme.css";
-
 .as-header {
   background-color: var(--color-secondary);
   opacity: 0.95;

--- a/src/components/header/header.ts
+++ b/src/components/header/header.ts
@@ -1,14 +1,21 @@
-import { css, html, LitElement, unsafeCSS, TemplateResult } from 'lit';
+import { html, LitElement, TemplateResult } from 'lit';
 import { customElement } from 'lit/decorators.js';
 import '../navigation/navigation.ts';
 import headerCss from './header.css?type=css';
 
 @customElement('app-header')
 export class HeaderComponent extends LitElement {
-  static styles = css`${unsafeCSS(headerCss)}`;
 
+  createRenderRoot(): Element | ShadowRoot {
+    return this;
+  }
+  
   protected render(): TemplateResult {
     return html`
+      <style>
+        ${headerCss}
+      </style>
+
       <header class="as-header">
         <div id="as-inner-header">
           <h1 class="as-header__logo"><a title="Home Page" href="/">Analog Studios</a></h1>

--- a/src/components/navigation/navigation.css
+++ b/src/components/navigation/navigation.css
@@ -1,10 +1,10 @@
-@import '../../theme.css';
-
-:host {
+.host {
   flex-grow: 1;
 }
 
 .as-navigation {
+  flex-grow: 1;
+
   & .as-navigation__list {
     display: flex;
     align-items: center;
@@ -17,9 +17,9 @@
   }
 
   & .as-navigation__list-item {
-      width: 100%;
-      text-align: center;
-      padding: 10px 0;
+    width: 100%;
+    text-align: center;
+    padding: 10px 0;
   }
 
   & .as-navigation__link {

--- a/src/components/navigation/navigation.ts
+++ b/src/components/navigation/navigation.ts
@@ -1,32 +1,41 @@
-import { css, html, LitElement, unsafeCSS, TemplateResult } from 'lit';
+import { html, LitElement, TemplateResult } from 'lit';
 import { customElement } from 'lit/decorators.js';
 import navigationCss from './navigation.css?type=css';
 
 @customElement('app-navigation')
 export class NavigationComponent extends LitElement {
-  static styles = css`${unsafeCSS(navigationCss)}`;
+
+  createRenderRoot(): Element | ShadowRoot {
+    return this;
+  }
 
   protected render(): TemplateResult {
     return html`
-      <nav class="as-navigation">
-        <ul class="list-unstyled as-navigation__list">
-          <li class="as-navigation__list-item">
-            <a class="as-navigation__link" href="/artists/">artists</a>
-          </li>
+      <style>
+        ${navigationCss}
+      </style>
+      
+      <div class="host">
+        <nav class="as-navigation">
+          <ul class="list-unstyled as-navigation__list">
+            <li class="as-navigation__list-item">
+              <a class="as-navigation__link" href="/artists/">artists</a>
+            </li>
 
-          <li class="as-navigation__list-item">
-            <a class="as-navigation__link" href="/albums/">albums</a>
-          </li>
+            <li class="as-navigation__list-item">
+              <a class="as-navigation__link" href="/albums/">albums</a>
+            </li>
 
-          <li class="as-navigation__list-item">
-            <a class="as-navigation__link" href="/events/">events</a>
-          </li>
+            <li class="as-navigation__list-item">
+              <a class="as-navigation__link" href="/events/">events</a>
+            </li>
 
-          <li class="as-navigation__list-item">
-            <a class="as-navigation__link" href="/contact/">contact</a>
-          </li>
-        </ul>
-      </nav>
+            <li class="as-navigation__list-item">
+              <a class="as-navigation__link" href="/contact/">contact</a>
+            </li>
+          </ul>
+        </nav>
+      </div>
     `;
   }
 }

--- a/src/components/posts-list/posts-list.css
+++ b/src/components/posts-list/posts-list.css
@@ -1,6 +1,4 @@
-@import '../../theme.css';
-
-:host img {
+.host img {
   display: block;
   max-width: 100%;
   height: auto;

--- a/src/components/posts-list/posts-list.ts
+++ b/src/components/posts-list/posts-list.ts
@@ -35,27 +35,30 @@ export class PostsListComponent extends LitElement {
       <style>
         ${postsListCss}
       </style>
-      <div class="as-posts-list">
 
-        <h3 class="as-posts-list__heading">Latest Posts</h3>
-        <div class="posts">
-          ${
-            maxPosts.map((post) => {
-              const formattedDate = this.getFormateDate(post.createdTime * 1000);
+      <div class="host">
+        <div class="as-posts-list">
 
-              return html`
-                <div class="post">
-                  <div class="post__time">Posted: ${formattedDate}</div>
+          <h3 class="as-posts-list__heading">Latest Posts</h3>
+          <div class="posts">
+            ${
+              maxPosts.map((post) => {
+                const formattedDate = this.getFormateDate(post.createdTime * 1000);
 
-                  <h4 class="post__heading">${post.title}</h4>
+                return html`
+                  <div class="post">
+                    <div class="post__time">Posted: ${formattedDate}</div>
 
-                  <details class="post__summary">${unsafeHTML(post.summary)}</details>
-                </div>
-              `;
-            })
-          }
+                    <h4 class="post__heading">${post.title}</h4>
+
+                    <details class="post__summary">${unsafeHTML(post.summary)}</details>
+                  </div>
+                `;
+              })
+            }
+          </div>
+
         </div>
-
       </div>
     `;
   }

--- a/src/routes/home/home.css
+++ b/src/routes/home/home.css
@@ -1,86 +1,81 @@
-@import '../../theme.css';
-@import '../../styles.css';
+.as-view-home {
+  margin-bottom: 15px;
 
-:host {
-  & .as-view-home {
-    margin-bottom: 15px;
+  & .as-media-carousel {
+    /* @include media-breakpoint-down(xs) {
+      margin-top: -30px;
+    }
 
-    & .as-media-carousel {
-      /* @include media-breakpoint-down(xs) {
-        margin-top: -30px;
-      }
+    @include media-breakpoint-only(sm) {
+      margin-top: 0;
+    } */
 
-      @include media-breakpoint-only(sm) {
-        margin-top: 0;
-      } */
+    position: relative;
+    margin: 0 -15px 30px -15px;
+    display: flex;
+    flex-direction: column;
+    margin-bottom: 60px;
+  }
 
-      position: relative;
-      margin: 0 -15px 30px -15px;
-      display: flex;
+  & .as-media-carousel__label {
+    padding: 15px;
+    background-color: var(--color-tertiary); /*transparentize($creme, .1);*/
+    font-size: 1.25rem;
+    letter-spacing: 2px;
+    margin-top: -95px;
+    opacity: 0.9;
+
+    @media(max-width: 768px) {
+      margin-top: 0;
+    }
+  }
+
+  & .as-media-carousel__attribution-label {
+    position: absolute;
+    bottom: -35px;
+    right: 0px;
+    padding: 2px 4px;
+    background: var(--color-dark); /* transparentize($black, .5); */
+    font-size: .5rem;
+    opacity: 0.7;
+
+    @media(max-width: 768px) {
+      bottom: 90px;
+    }
+  }
+
+  & .as-media-carousel__attribution-label,
+  & .as-media-carousel__attribution-label-link {
+    color: var(--color-tertiary);
+  }
+
+  & .as-media-carousel__label,
+  & .as-media-carousel__attribution-label {
+    @include media-breakpoint-down(sm) {
+      display: none;
+    }
+  }
+  & .as-info-container {
+    display: flex;
+    justify-content: space-between;
+
+    @media(max-width: 768px) {
       flex-direction: column;
-      margin-bottom: 60px;
     }
+  }
 
-    & .as-media-carousel__label {
-      padding: 15px;
-      background-color: var(--color-tertiary); /*transparentize($creme, .1);*/
-      font-size: 1.25rem;
-      letter-spacing: 2px;
-      margin-top: -95px;
-      opacity: 0.9;
+  & .as-info-content {
+    width: 48%;
 
-      @media(max-width: 768px) {
-        margin-top: 0;
+    @media(max-width: 768px) {
+      width: 100%;
+      &:nth-child(2) {
+        margin-top: 2rem;
       }
     }
+  }
 
-    & .as-media-carousel__attribution-label {
-      position: absolute;
-      bottom: -35px;
-      right: 0px;
-      padding: 2px 4px;
-      background: var(--color-dark); /* transparentize($black, .5); */
-      font-size: .5rem;
-      opacity: 0.7;
-
-      @media(max-width: 768px) {
-        bottom: 90px;
-      }
-    }
-
-    & .as-media-carousel__attribution-label,
-    & .as-media-carousel__attribution-label-link {
-      color: var(--color-tertiary);
-    }
-
-    & .as-media-carousel__label,
-    & .as-media-carousel__attribution-label {
-      @include media-breakpoint-down(sm) {
-        display: none;
-      }
-    }
-    & .as-info-container {
-      display: flex;
-      justify-content: space-between;
-
-      @media(max-width: 768px) {
-        flex-direction: column;
-      }
-    }
-
-    & .as-info-content {
-      width: 48%;
-
-      @media(max-width: 768px) {
-        width: 100%;
-        &:nth-child(2) {
-          margin-top: 2rem;
-        }
-      }
-    }
-
-    & .as-welcome {
-      margin-bottom: 45px;
-    }
+  & .as-welcome {
+    margin-bottom: 45px;
   }
 }

--- a/src/theme.css
+++ b/src/theme.css
@@ -1,6 +1,3 @@
-@import "../node_modules/font-awesome/css/font-awesome.css";
-@import "../node_modules/bootstrap/dist/css/bootstrap.css";
-
 :root, :host {
   /* raw tokens */
   --white: #efefef;


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
related to #28 

## Summary of Changes
1. Made all CSS global by having all WCs that need global styles access override `createRenderRoot` and just spit out `<style>` tags
1. Removed all dupe `@imports` and made all CSS "singletons" and each WC isn't carrying a copy of FA and Bootstrap  

This has significantly improved bundle size!

#### Before
JS + CSS = 1.3MB
![Screen Shot 2021-12-09 at 5 47 04 PM](https://user-images.githubusercontent.com/895923/145490977-69fd2959-2d92-4171-b098-ae8a5035e98b.png)


#### After
JS + CSS = 289 KB 😮 
![Screen Shot 2021-12-09 at 5 46 27 PM](https://user-images.githubusercontent.com/895923/145490956-e9374673-7582-44e2-95d9-fc4ffa701305.png)

## TODO
1. [ ] Header navigation styles are off
1. [ ] FA icons are missing
1. [ ] Posts / Events font sizes are smaller compared to preview version

![Screen Shot 2021-12-09 at 6 24 21 PM](https://user-images.githubusercontent.com/895923/145491345-d2bb1a21-b1fb-481d-9724-061aeb79aeb6.png)
![Screen Shot 2021-12-09 at 6 24 27 PM](https://user-images.githubusercontent.com/895923/145491346-b73c2f70-ef88-4a5c-ac57-af367b791b8a.png)