### PR TITLE
remove hard limit on viewable calendar tiles

### DIFF
--- a/src/components/events-calendar/events-calendar.ts
+++ b/src/components/events-calendar/events-calendar.ts
@@ -9,7 +9,7 @@ import eventsCalendarCss from './events-calendar.css?type=css';
 export class EventsCalendarComponent extends LitElement {
 
   private DAYS_IN_WEEK = 7;
-  private MAX_CALENDAR_SPACES = 35;
+  private MAX_CALENDAR_SPACES = 42;
   private CALENDAR = [
     { NAME: 'January', DAYS: 31 },
     { NAME: 'February', DAYS: 28 },


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
resolves #23 

## Summary of Changes
1. Removed pre-mature hard limit on viewable tiles

> As a nice to have and as [captured here](https://github.com/AnalogStudiosRI/www.analogstudios.net/issues/23#issuecomment-1001827320), it would be nice to see if I could hide full empty rows.  That said, keeping the number of rows consistent might be better UX?  I could see it going wither way, so certainly not a blocker.