### PR TITLE
Bug/issue 5 properly size embed images

### DIFF
--- a/src/routes/events/events.css
+++ b/src/routes/events/events.css
@@ -29,6 +29,10 @@
   @media(max-width: 768px) {
     margin: 1rem 0;
   }
+
+  img {
+    width: 100%;
+  }
 }
 
 #as-event-detail-container {


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
https://github.com/AnalogStudiosRI/api/issues/5

## Summary of Changes
1. Properly size images from rich text CMS content and https://github.com/AnalogStudiosRI/api/pull/12

<details>
before
<img src="https://user-images.githubusercontent.com/895923/179650506-0999fdc4-0ca0-4f1c-82b4-c6cad4a1af7d.png">

after
<img src="https://user-images.githubusercontent.com/895923/179650553-5cc84f9c-0ba7-4a56-9868-37bdef0a34da.png">
</details>