### PR TITLE
upgrade to latest version of typescript and lit

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "@storybook/addon-postcss": "^2.0.0",
     "@storybook/web-components": "^6.3.2",
     "@typescript-eslint/eslint-plugin": "^5.4.0",
-    "@typescript-eslint/parser": "^5.4.0",
+    "@typescript-eslint/parser": "^6.6.0",
     "@web/test-runner": "^0.13.13",
     "@web/test-runner-junit-reporter": "^0.4.4",
     "@web/test-runner-puppeteer": "^0.10.2",

--- a/package.json
+++ b/package.json
@@ -32,13 +32,10 @@
     "test": "wtr",
     "test:tdd": "yarn test --watch"
   },
-  "resolutions": {
-    "typescript": "^4.3.5"
-  },
   "dependencies": {
     "bootstrap": "4.0.0-alpha.4",
     "font-awesome": "4.6.3",
-    "lit": "^2.0.0-rc.2",
+    "lit": "^3.0.0",
     "lit-redux-router": "~0.19.0",
     "pwa-helpers": "^0.9.1",
     "redux": "^4.0.5",
@@ -76,7 +73,6 @@
     "rollup-plugin-visualizer": "^5.5.2",
     "stylelint": "^13.8.0",
     "stylelint-a11y": "^1.2.3",
-    "stylelint-config-standard": "^20.0.0",
-    "typescript": "^4.5.2"
+    "stylelint-config-standard": "^20.0.0"
   }
 }

--- a/src/components/card/card.model.ts
+++ b/src/components/card/card.model.ts
@@ -1,5 +1,5 @@
-import { Artist } from '../../services/artists/artist.model';
-import { Album } from '../../services/albums/album.model';
+import { Artist } from '../../services/artists/artist.model.ts';
+import { Album } from '../../services/albums/album.model.ts';
 
 function modelAlbum(album: Album) {
   return {

--- a/src/components/card/card.ts
+++ b/src/components/card/card.ts
@@ -6,7 +6,8 @@ import cardCss from './card.css?type=css';
 
 @customElement('app-card')
 export class CardComponent extends LitElement {
-  @property() details: Details;
+  @property()
+  accessor details: Details;
 
   static styles = css`${unsafeCSS(cardCss)}`;
 

--- a/src/components/events-calendar/events-calendar.ts
+++ b/src/components/events-calendar/events-calendar.ts
@@ -26,9 +26,14 @@ export class EventsCalendarComponent extends LitElement {
   ];
   private currentMonthData = [[Event]];
 
-  @property() events = [];
-  @property() currentMonthIndex;
-  @property() currentYear;
+  @property()
+  accessor events = [];
+
+  @property()
+  accessor currentMonthIndex;
+
+  @property()
+  accessor currentYear;
 
   constructor() {
     super();

--- a/src/components/footer/footer.ts
+++ b/src/components/footer/footer.ts
@@ -8,7 +8,7 @@ export class FooterComponent extends LitElement {
 
   @property()
   private accessor STARTING_YEAR = 2007;
-  
+
   @property()
   private accessor currentYear = new Date().getFullYear();
 

--- a/src/components/footer/footer.ts
+++ b/src/components/footer/footer.ts
@@ -6,8 +6,11 @@ import footerCss from './footer.css?type=css';
 export class FooterComponent extends LitElement {
   static styles = css`${unsafeCSS(footerCss)}`;
 
-  @property() private STARTING_YEAR = 2007;
-  @property() private currentYear = new Date().getFullYear();
+  @property()
+  private accessor STARTING_YEAR = 2007;
+  
+  @property()
+  private accessor currentYear = new Date().getFullYear();
 
   protected render(): TemplateResult {
     const { currentYear, STARTING_YEAR } = this;

--- a/src/components/posts-list/posts-list.ts
+++ b/src/components/posts-list/posts-list.ts
@@ -6,8 +6,11 @@ import postsListCss from './posts-list.css?type=css';
 
 @customElement('app-posts-list')
 export class PostsListComponent extends LitElement {
-  @property() max = 0;
-  @property() posts = [];
+  @property()
+  accessor max = 0;
+
+  @property()
+  accessor posts = [];
 
   async connectedCallback() {
     super.connectedCallback();

--- a/src/components/social-share/social-share.ts
+++ b/src/components/social-share/social-share.ts
@@ -7,7 +7,9 @@ import 'web-social-share';
 export class NavigationComponent extends LitElement {
   static styles = css`${unsafeCSS(socialShareCss)}`;
 
-  @property() show = false;
+  @property()
+  accessor show = false;
+
   shareConfig = {};
 
   constructor() {

--- a/src/routes/albums/album-details.ts
+++ b/src/routes/albums/album-details.ts
@@ -11,8 +11,11 @@ import albumsCss from './albums.css?type=css';
 @customElement('as-route-album-details')
 export class AlbumDetailsRouteComponent extends LitElement {
 
-  @property() id: string;
-  @property() album: Album;
+  @property()
+  accessor id: string;
+
+  @property()
+  accessor album: Album;
 
   async connectedCallback() {
     super.connectedCallback();

--- a/src/routes/albums/albums.ts
+++ b/src/routes/albums/albums.ts
@@ -12,7 +12,8 @@ import albumsCss from './albums.css?type=css';
 @customElement('as-route-albums')
 export class AlbumsRouteComponent extends LitElement {
 
-  @property() albums: Array<Album> = [];
+  @property()
+  accessor albums: Array<Album> = [];
 
   async connectedCallback() {
     super.connectedCallback();

--- a/src/routes/artists/artist-details.ts
+++ b/src/routes/artists/artist-details.ts
@@ -6,7 +6,7 @@ import { getArtistById } from '../../services/artists/artists-service.ts';
 import { getAlbumsByArtistId } from '../../services/albums/albums-service.ts';
 import { modelArtist, modelAlbum } from '../../components/card/card.model.ts';
 import { Artist } from '../../services/artists/artist.model.ts';
-import { Album } from '../../services/album/album.model.ts';
+import { Album } from '../../services/albums/album.model.ts';
 import '../../components/card/card.ts';
 import '../../components/social-share/social-share.ts';
 import artistsCss from './artists.css?type=css';
@@ -14,9 +14,14 @@ import artistsCss from './artists.css?type=css';
 @customElement('as-route-artist-details')
 export class ArtistDetailsRouteComponent extends LitElement {
 
-  @property() id: string;
-  @property() artist: Artist;
-  @property() albums: Array<Album>;
+  @property()
+  accessor id: string;
+
+  @property()
+  accessor artist: Artist;
+
+  @property()
+  accessor albums: Array<Album>;
 
   async connectedCallback() {
     super.connectedCallback();

--- a/src/routes/artists/artists.ts
+++ b/src/routes/artists/artists.ts
@@ -14,9 +14,10 @@ export class ArtistsRouteComponent extends LitElement {
 
   private ANALOG_ID = '1';
   private displayArtists: Array<Artist> = [];
-  private analog: Artist = {};
+  private analog: Artist;
 
-  @property() artists: Array<Artist> = [];
+  @property()
+  accessor artists: Array<Artist> = [];
 
   async connectedCallback() {
     super.connectedCallback();
@@ -33,14 +34,14 @@ export class ArtistsRouteComponent extends LitElement {
   }
 
   private onArtistSelected(): void {
-    const selectedAristId = this.shadowRoot.querySelector('select').value;
+    const selectedArtistId = this.shadowRoot.querySelector('select').value;
 
-    store.dispatch(navigate(`/artists/${selectedAristId}`));
+    store.dispatch(navigate(`/artists/${selectedArtistId}`));
   }
 
   /* eslint-disable indent */
   protected render(): TemplateResult {
-    const { displayArtists, analog } = this;
+    const { displayArtists = [], analog = {} } = this;
 
     return html`
       <style>

--- a/src/routes/contact/contact.ts
+++ b/src/routes/contact/contact.ts
@@ -5,7 +5,7 @@ import contactCss from './contact.css?type=css';
 @customElement('as-route-contact')
 export class ContactRouteComponent extends LitElement {
 
-  protected connectedCallback(): void {
+  connectedCallback(): void {
     super.connectedCallback();
 
     ga('set', 'page', '/contact');

--- a/src/routes/events/event-details.ts
+++ b/src/routes/events/event-details.ts
@@ -12,8 +12,11 @@ export class EventDetailsRouteComponent extends LitElement {
   private MONTHS = ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'];
   private DAYS = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
 
-  @property() id: string;
-  @property() event: Event;
+  @property()
+  accessor id: string;
+
+  @property()
+  accessor event: Event;
 
   async connectedCallback() {
     super.connectedCallback();

--- a/src/routes/events/events.ts
+++ b/src/routes/events/events.ts
@@ -7,7 +7,7 @@ import eventsCss from './events.css?type=css';
 @customElement('as-route-events')
 export class EventsRouteComponent extends LitElement {
 
-  protected connectedCallback(): void {
+  connectedCallback(): void {
     super.connectedCallback();
 
     ga('set', 'page', '/events');

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,12 +1,14 @@
 {
-  "exclude": [
-    "./node_modules/*"
-  ],
-  "include": [
-    "./**/*.ts"
-  ],
   "compilerOptions": {
-    "esModuleInterop": true,
-    "experimentalDecorators": true
-  }
+    "target": "es2022",
+    "module": "NodeNext",
+    "lib": ["es2022", "DOM", "DOM.Iterable", "esnext"],
+    "allowSyntheticDefaultImports": true,
+    "moduleResolution": "NodeNext",
+    "allowImportingTsExtensions": true,
+    "noEmit": true
+  },
+  "include": [
+    "./src/**/*.ts"
+  ],
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2737,10 +2737,17 @@
     "@jridgewell/resolve-uri" "3.1.0"
     "@jridgewell/sourcemap-codec" "1.4.14"
 
-"@lit/reactive-element@^1.0.0-rc.2":
-  version "1.0.0-rc.2"
-  resolved "https://registry.yarnpkg.com/@lit/reactive-element/-/reactive-element-1.0.0-rc.2.tgz#f24dba16ea571a08dca70f1783bd2ca5ec8de3ee"
-  integrity sha512-cujeIl5Ei8FC7UHf4/4Q3bRJOtdTe1vpJV/JEBYCggedmQ+2P8A2oz7eE+Vxi6OJ4nc0X+KZxXnBoH4QrEbmEQ==
+"@lit-labs/ssr-dom-shim@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.1.2.tgz#d693d972974a354034454ec1317eb6afd0b00312"
+  integrity sha512-jnOD+/+dSrfTWYfSXBXlo5l5f0q1UuJo3tkbMDCYA2lKUYq79jaxqtGEvnRoh049nt1vdo1+45RinipU6FGY2g==
+
+"@lit/reactive-element@^2.0.0":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@lit/reactive-element/-/reactive-element-2.0.1.tgz#b17d8818d9c72ccc489f44e35d87cfa18a9c8c93"
+  integrity sha512-eu50SQXHRthFwWJMp0oAFg95Rvm6MTPjxSXWuvAu7It90WVFLFpNBoIno7XOXSDvVgTrtKnUV4OLJqys2Svn4g==
+  dependencies:
+    "@lit-labs/ssr-dom-shim" "^1.1.2"
 
 "@ls-lint/ls-lint@^1.10.0":
   version "1.10.0"
@@ -4081,10 +4088,10 @@
   resolved "https://registry.yarnpkg.com/@types/tapable/-/tapable-1.0.8.tgz#b94a4391c85666c7b73299fd3ad79d4faa435310"
   integrity sha512-ipixuVrh2OdNmauvtT51o3d8z12p6LtFW9in7U79der/kwejjdNchQC5UMn5u/KxNoM7VHHOs/l8KS8uHxhODQ==
 
-"@types/trusted-types@^1.0.1":
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/@types/trusted-types/-/trusted-types-1.0.6.tgz#569b8a08121d3203398290d602d84d73c8dcf5da"
-  integrity sha512-230RC8sFeHoT6sSUlRO6a8cAnclO06eeiq1QDfiv2FGCLWFvvERWgwIQD4FWqD9A69BN7Lzee4OXwoMVnnsWDw==
+"@types/trusted-types@^2.0.2":
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/@types/trusted-types/-/trusted-types-2.0.5.tgz#5cac7e7df3275bb95f79594f192d97da3b4fd5fe"
+  integrity sha512-I3pkr8j/6tmQtKV/ZzHtuaqYSQvyjGRKH4go60Rr0IDLlFxuRT5V32uvB1mecM5G1EVAUyF/4r4QZ1GHgz+mxA==
 
 "@types/uglify-js@*":
   version "3.13.1"
@@ -9353,20 +9360,21 @@ list-item@^1.1.1:
     is-number "^2.1.0"
     repeat-string "^1.5.2"
 
-lit-element@^3.0.0-rc.2:
-  version "3.0.0-rc.2"
-  resolved "https://registry.yarnpkg.com/lit-element/-/lit-element-3.0.0-rc.2.tgz#883d0b6fd7b846226d360699d1b713da5fc7e1b7"
-  integrity sha512-2Z7DabJ3b5K+p5073vFjMODoaWqy5PIaI4y6ADKm+fCGc8OnX9fU9dMoUEBZjFpd/bEFR9PBp050tUtBnT9XTQ==
+lit-element@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/lit-element/-/lit-element-4.0.1.tgz#fe9d82e2d034f819156f561f6f23b0ed0c9d19dc"
+  integrity sha512-OxRMJem4HKZt0320HplLkBPoi4KHiEHoPHKd8Lzf07ZQVAOKIjZ32yPLRKRDEolFU1RgrQBfSHQMoxKZ72V3Kw==
   dependencies:
-    "@lit/reactive-element" "^1.0.0-rc.2"
-    lit-html "^2.0.0-rc.3"
+    "@lit-labs/ssr-dom-shim" "^1.1.2"
+    "@lit/reactive-element" "^2.0.0"
+    lit-html "^3.0.0"
 
-lit-html@^2.0.0-rc.3:
-  version "2.0.0-rc.3"
-  resolved "https://registry.yarnpkg.com/lit-html/-/lit-html-2.0.0-rc.3.tgz#1c216e548630e18d3093d97f4e29563abce659af"
-  integrity sha512-Y6P8LlAyQuqvzq6l/Nc4z5/P5M/rVLYKQIRxcNwSuGajK0g4kbcBFQqZmgvqKG+ak+dHZjfm2HUw9TF5N/pkCw==
+lit-html@^3.0.0:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/lit-html/-/lit-html-3.0.2.tgz#25d2718b1e095a148a54c63bcd780c7550bb82f8"
+  integrity sha512-Q1A5lHza3bnmxoWJn6yS6vQZQdExl4fghk8W1G+jnAEdoFNYo5oeBBb/Ol7zSEdKd3TR7+r0zsJQyuWEVguiyQ==
   dependencies:
-    "@types/trusted-types" "^1.0.1"
+    "@types/trusted-types" "^2.0.2"
 
 lit-redux-router@~0.19.0:
   version "0.19.1"
@@ -9375,14 +9383,14 @@ lit-redux-router@~0.19.0:
   dependencies:
     regexparam "^2.0.0"
 
-lit@^2.0.0-rc.2:
-  version "2.0.0-rc.2"
-  resolved "https://registry.yarnpkg.com/lit/-/lit-2.0.0-rc.2.tgz#724a2d621aa098001d73bf7106f3a72b7b5948ef"
-  integrity sha512-BOCuoJR04WaTV8UqTKk09cNcQA10Aq2LCcBOiHuF7TzWH5RNDsbCBP5QM9sLBSotGTXbDug/gFO08jq6TbyEtw==
+lit@^3.0.0:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/lit/-/lit-3.0.2.tgz#e22e90c2cbcc3f37bf3c2558df66f3af4331c9cf"
+  integrity sha512-ZoVUPGgXOQocP4OvxehEOBmC4rWB4cRYDPaz7aFmH8DFytsCi/NeACbr4C6vNPGDEC07BrhUos7uVNayDKLQ2Q==
   dependencies:
-    "@lit/reactive-element" "^1.0.0-rc.2"
-    lit-element "^3.0.0-rc.2"
-    lit-html "^2.0.0-rc.3"
+    "@lit/reactive-element" "^2.0.0"
+    lit-element "^4.0.0"
+    lit-html "^3.0.0"
 
 livereload-js@^3.3.1:
   version "3.3.2"
@@ -13362,10 +13370,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^4.3.5, typescript@^4.5.2, typescript@^5.1.6:
-  version "4.5.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.5.2.tgz#8ac1fba9f52256fdb06fb89e4122fa6a346c2998"
-  integrity sha512-5BlMof9H1yGt0P8/WF+wPNw6GfctgGjXp5hkblpyT+8rkASSmkUKMXrxR0Xg8ThVCi/JnHQiKXeBaEwCeQwMFw==
+typescript@^5.1.6:
+  version "5.2.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.2.2.tgz#5ebb5e5a5b75f085f22bc3f8460fba308310fa78"
+  integrity sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==
 
 typical@^4.0.0:
   version "4.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4188,15 +4188,16 @@
     eslint-scope "^5.1.1"
     eslint-utils "^3.0.0"
 
-"@typescript-eslint/parser@^5.4.0":
-  version "5.4.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-5.4.0.tgz#3aa83ce349d66e39b84151f6d5464928044ca9e3"
-  integrity sha512-JoB41EmxiYpaEsRwpZEYAJ9XQURPFer8hpkIW9GiaspVLX8oqbqNM8P4EP8HOZg96yaALiLEVWllA2E8vwsIKw==
+"@typescript-eslint/parser@^6.6.0":
+  version "6.9.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-6.9.1.tgz#4f685f672f8b9580beb38d5fb99d52fc3e34f7a3"
+  integrity sha512-C7AK2wn43GSaCUZ9do6Ksgi2g3mwFkMO3Cis96kzmgudoVaKyt62yNzJOktP0HDLb/iO2O0n2lBOzJgr6Q/cyg==
   dependencies:
-    "@typescript-eslint/scope-manager" "5.4.0"
-    "@typescript-eslint/types" "5.4.0"
-    "@typescript-eslint/typescript-estree" "5.4.0"
-    debug "^4.3.2"
+    "@typescript-eslint/scope-manager" "6.9.1"
+    "@typescript-eslint/types" "6.9.1"
+    "@typescript-eslint/typescript-estree" "6.9.1"
+    "@typescript-eslint/visitor-keys" "6.9.1"
+    debug "^4.3.4"
 
 "@typescript-eslint/scope-manager@5.4.0":
   version "5.4.0"
@@ -4206,10 +4207,23 @@
     "@typescript-eslint/types" "5.4.0"
     "@typescript-eslint/visitor-keys" "5.4.0"
 
+"@typescript-eslint/scope-manager@6.9.1":
+  version "6.9.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-6.9.1.tgz#e96afeb9a68ad1cd816dba233351f61e13956b75"
+  integrity sha512-38IxvKB6NAne3g/+MyXMs2Cda/Sz+CEpmm+KLGEM8hx/CvnSRuw51i8ukfwB/B/sESdeTGet1NH1Wj7I0YXswg==
+  dependencies:
+    "@typescript-eslint/types" "6.9.1"
+    "@typescript-eslint/visitor-keys" "6.9.1"
+
 "@typescript-eslint/types@5.4.0":
   version "5.4.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.4.0.tgz#b1c130f4b381b77bec19696c6e3366f9781ce8f2"
   integrity sha512-GjXNpmn+n1LvnttarX+sPD6+S7giO+9LxDIGlRl4wK3a7qMWALOHYuVSZpPTfEIklYjaWuMtfKdeByx0AcaThA==
+
+"@typescript-eslint/types@6.9.1":
+  version "6.9.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-6.9.1.tgz#a6cfc20db0fcedcb2f397ea728ef583e0ee72459"
+  integrity sha512-BUGslGOb14zUHOUmDB2FfT6SI1CcZEJYfF3qFwBeUrU6srJfzANonwRYHDpLBuzbq3HaoF2XL2hcr01c8f8OaQ==
 
 "@typescript-eslint/typescript-estree@5.4.0":
   version "5.4.0"
@@ -4224,6 +4238,19 @@
     semver "^7.3.5"
     tsutils "^3.21.0"
 
+"@typescript-eslint/typescript-estree@6.9.1":
+  version "6.9.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-6.9.1.tgz#8c77910a49a04f0607ba94d78772da07dab275ad"
+  integrity sha512-U+mUylTHfcqeO7mLWVQ5W/tMLXqVpRv61wm9ZtfE5egz7gtnmqVIw9ryh0mgIlkKk9rZLY3UHygsBSdB9/ftyw==
+  dependencies:
+    "@typescript-eslint/types" "6.9.1"
+    "@typescript-eslint/visitor-keys" "6.9.1"
+    debug "^4.3.4"
+    globby "^11.1.0"
+    is-glob "^4.0.3"
+    semver "^7.5.4"
+    ts-api-utils "^1.0.1"
+
 "@typescript-eslint/visitor-keys@5.4.0":
   version "5.4.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.4.0.tgz#09bc28efd3621f292fe88c86eef3bf4893364c8c"
@@ -4231,6 +4258,14 @@
   dependencies:
     "@typescript-eslint/types" "5.4.0"
     eslint-visitor-keys "^3.0.0"
+
+"@typescript-eslint/visitor-keys@6.9.1":
+  version "6.9.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-6.9.1.tgz#6753a9225a0ba00459b15d6456b9c2780b66707d"
+  integrity sha512-MUaPUe/QRLEffARsmNfmpghuQkW436DvESW+h+M52w0coICHRfD6Np9/K6PdACwnrq1HmuLl+cSPZaJmeVPkSw==
+  dependencies:
+    "@typescript-eslint/types" "6.9.1"
+    eslint-visitor-keys "^3.4.1"
 
 "@web/browser-logs@^0.2.1", "@web/browser-logs@^0.2.2":
   version "0.2.4"
@@ -6419,6 +6454,13 @@ debug@^3.0.0, debug@^3.1.0, debug@^3.1.1:
   dependencies:
     ms "^2.1.1"
 
+debug@^4.3.4:
+  version "4.3.4"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
+  integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
+  dependencies:
+    ms "2.1.2"
+
 debug@~3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
@@ -7039,6 +7081,11 @@ eslint-visitor-keys@^3.0.0:
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-3.1.0.tgz#eee4acea891814cda67a7d8812d9647dd0179af2"
   integrity sha512-yWJFpu4DtjsWKkt5GeNBBuZMlNcYVs6vRCLoCVEJrTjaSB6LC98gFipNK/erM2Heg/E8mIK+hXG/pJMLK+eRZA==
 
+eslint-visitor-keys@^3.4.1:
+  version "3.4.3"
+  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz#0cd72fe8550e3c2eae156a96a4dddcd1c8ac5800"
+  integrity sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==
+
 eslint@^8.2.0:
   version "8.2.0"
   resolved "https://registry.yarnpkg.com/eslint/-/eslint-8.2.0.tgz#44d3fb506d0f866a506d97a0fc0e90ee6d06a815"
@@ -7301,6 +7348,17 @@ fast-glob@^3.1.1, fast-glob@^3.2.5:
   version "3.2.7"
   resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.7.tgz#fd6cb7a2d7e9aa7a7846111e85a196d6b2f766a1"
   integrity sha512-rYGMRwip6lUMvYD3BTScMwT1HtAs2d71SMv66Vrxs0IekGZEjhM0pcMfjQPnknBt2zeCwQMEupiN02ZP4DiT1Q==
+  dependencies:
+    "@nodelib/fs.stat" "^2.0.2"
+    "@nodelib/fs.walk" "^1.2.3"
+    glob-parent "^5.1.2"
+    merge2 "^1.3.0"
+    micromatch "^4.0.4"
+
+fast-glob@^3.2.9:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.3.1.tgz#784b4e897340f3dbbef17413b3f11acf03c874c4"
+  integrity sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==
   dependencies:
     "@nodelib/fs.stat" "^2.0.2"
     "@nodelib/fs.walk" "^1.2.3"
@@ -7918,6 +7976,18 @@ globby@^11.0.1, globby@^11.0.2, globby@^11.0.3, globby@^11.0.4:
     merge2 "^1.3.0"
     slash "^3.0.0"
 
+globby@^11.1.0:
+  version "11.1.0"
+  resolved "https://registry.yarnpkg.com/globby/-/globby-11.1.0.tgz#bd4be98bb042f83d796f7e3811991fbe82a0d34b"
+  integrity sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==
+  dependencies:
+    array-union "^2.1.0"
+    dir-glob "^3.0.1"
+    fast-glob "^3.2.9"
+    ignore "^5.2.0"
+    merge2 "^1.4.1"
+    slash "^3.0.0"
+
 globby@^9.2.0:
   version "9.2.0"
   resolved "https://registry.yarnpkg.com/globby/-/globby-9.2.0.tgz#fd029a706c703d29bdd170f4b6db3a3f7a7cb63d"
@@ -8402,6 +8472,11 @@ ignore@^5.1.4, ignore@^5.1.8:
   version "5.1.8"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.8.tgz#f150a8b50a34289b33e22f5889abd4d8016f0e57"
   integrity sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==
+
+ignore@^5.2.0:
+  version "5.2.4"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.2.4.tgz#a291c0c6178ff1b960befe47fcdec301674a6324"
+  integrity sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==
 
 immer@8.0.1:
   version "8.0.1"
@@ -9842,7 +9917,7 @@ merge-stream@^2.0.0:
   resolved "https://registry.yarnpkg.com/merge-stream/-/merge-stream-2.0.0.tgz#52823629a14dd00c9770fb6ad47dc6310f2c1f60"
   integrity sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==
 
-merge2@^1.2.3, merge2@^1.3.0:
+merge2@^1.2.3, merge2@^1.3.0, merge2@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
   integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
@@ -12274,6 +12349,13 @@ semver@^7.2.1, semver@^7.3.2, semver@^7.3.4, semver@^7.3.5:
   dependencies:
     lru-cache "^6.0.0"
 
+semver@^7.5.4:
+  version "7.5.4"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.5.4.tgz#483986ec4ed38e1c6c48c34894a9182dbff68a6e"
+  integrity sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==
+  dependencies:
+    lru-cache "^6.0.0"
+
 send@0.17.1:
   version "0.17.1"
   resolved "https://registry.yarnpkg.com/send/-/send-0.17.1.tgz#c1d8b059f7900f7466dd4938bdc44e11ddb376c8"
@@ -13263,6 +13345,11 @@ trough@^1.0.0:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/trough/-/trough-1.0.5.tgz#b8b639cefad7d0bb2abd37d433ff8293efa5f406"
   integrity sha512-rvuRbTarPXmMb79SmzEp8aqXNKcK+y0XaB298IXueQ8I2PsrATcPBCSPyK/dDNa2iWOhKlfNnOjdAOTBU/nkFA==
+
+ts-api-utils@^1.0.1:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/ts-api-utils/-/ts-api-utils-1.0.3.tgz#f12c1c781d04427313dbac808f453f050e54a331"
+  integrity sha512-wNMeqtMz5NtwpT/UZGY5alT+VoKdSsOOP/kqHFcUW1P/VRhH2wJ48+DN2WwUliNbQ976ETwDL0Ifd2VVvgonvg==
 
 ts-dedent@^2.0.0, ts-dedent@^2.1.1:
   version "2.2.0"


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
resolves #90 

## Summary of Changes
1. Upgrade to latest version of TypeScript with out of the box decorators support
1. Upgrade to Lit 3

## TODO
1. [x] Fix linting
    ```sh
    /Users/owenbuckley/Workspace/analogstudiosri/www.analogstudios.net/web-test-runner.config.js
    0:0  error  Parsing error: DeprecationError: 'originalKeywordKind' has been deprecated since v5.0.0 and can no longer be used. Use 'identifierToKeywordKind(identifier)' instead
    ```