### PR TITLE
bug/restore to old API endpoints

### DIFF
--- a/src/services/albums/albums-service.ts
+++ b/src/services/albums/albums-service.ts
@@ -1,6 +1,6 @@
 import { Album } from './album.model.ts';
 
-const ALBUMS_API_URL = '/api/v2/albums';
+const ALBUMS_API_URL = '/api/albums';
 
 function getAlbums(): Promise<[Album]> {
   return fetch(ALBUMS_API_URL)

--- a/src/services/artists/artists-service.ts
+++ b/src/services/artists/artists-service.ts
@@ -1,6 +1,6 @@
 import { Artist } from './artist.model.ts';
 
-const ARTISTS_API_URL = '/api/v2/artists';
+const ARTISTS_API_URL = '/api/artists';
 
 // ensure only active artists are shown on the front end
 function isActive(artist: Artist): boolean {

--- a/src/services/events/events-service.ts
+++ b/src/services/events/events-service.ts
@@ -1,6 +1,6 @@
 import './event.model.ts';
 
-const EVENTS_API_URL = '/api/v2/events';
+const EVENTS_API_URL = '/api/events';
 
 function getEvents(): Promise<[Event]> {
   return fetch(EVENTS_API_URL)

--- a/src/services/posts/posts-service.ts
+++ b/src/services/posts/posts-service.ts
@@ -1,6 +1,6 @@
 import { Post } from './post.model.ts';
 
-const POSTS_API_URL = '/api/v2/posts';
+const POSTS_API_URL = '/api/posts';
 
 function getPosts(): Promise<[Post]> {
   return fetch(POSTS_API_URL)


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
coming out of https://github.com/AnalogStudiosRI/api/pull/44, we need to go back to the old `/api/*` API endpoints/

![Screenshot 2025-05-17 at 9 04 34 PM](https://github.com/user-attachments/assets/f9e66cf0-8ed7-4ecb-b7ee-a3e5edf09a9e)

## Summary of Changes
1. Remove `v2` suffix